### PR TITLE
Fixed website URL not linking to polymc.org.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Official Website for PolyMC
 
-polymc.org
+https://polymc.org
 
 ## local development 
 


### PR DESCRIPTION
Just added `https://` before the URL.